### PR TITLE
Implement CLI foundry, jq setup

### DIFF
--- a/src/bash.ts
+++ b/src/bash.ts
@@ -1,7 +1,7 @@
 import { spawn } from "child_process";
 import type { CommandResult } from "./types";
 
-export function runShellScript(command: string): Promise<CommandResult> {
+export function runShellScript(command: string, log: boolean = false): Promise<CommandResult> {
     return new Promise((resolve, reject) => {
         const childProcess = spawn("/bin/sh", ["-c", command]);
         let stdout = "";
@@ -9,10 +9,16 @@ export function runShellScript(command: string): Promise<CommandResult> {
 
         childProcess.stdout.on("data", (data: Buffer) => {
             stdout += data.toString();
+            if (log) {
+                console.log(stdout);
+            }
         });
 
         childProcess.stderr.on("data", (data: Buffer) => {
             stderr += data.toString();
+            if (log) {
+                console.error(stderr);
+            }
         });
 
         childProcess.on("close", (code: number) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,13 @@ import GPTAssistant from "./assistants/Gpt";
 import chalk from "chalk";
 import { getEnv } from "./utils";
 import { Cli } from "./cli";
+import { setup } from "./setup";
 
 const OPENAI_API_KEY = getEnv("OPENAI_API_KEY");
 const OPENAI_ASSISTANT_ID = getEnv("OPENAI_ASSISTANT_ID", null);
 
 async function main() {
+    await setup();
     const assistant = new GPTAssistant(OPENAI_API_KEY);
     await assistant.initSession(OPENAI_ASSISTANT_ID);
 

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,0 +1,37 @@
+import ora from "ora";
+import { runShellScript } from "./bash";
+import { logGreen } from "./logger";
+import chalk from "chalk";
+
+export const setup = async () => {
+    logGreen("🕵🏽‍♀️ Setting up...");
+    await installJq();
+    await installFoundry();
+    logGreen("🎉 Setup complete\n");
+}
+
+const installJq = async () => {
+    const spinner = ora("Installing jq").start();
+
+    const jqExists = await runShellScript("which jq");
+    if (jqExists.output === "") {
+        await runShellScript("curl -sS https://webi.sh/jq | sh", true);
+        spinner.succeed(chalk.green("JQ installed"));
+    }
+    else {
+        spinner.succeed(chalk.green("jq is aleady installed"));
+    }
+}
+
+const installFoundry = async () => {
+    const spinner = ora("Installing Foundry (this might take a while)").start();
+
+    const foundryExists = await runShellScript("which cast");
+    if (foundryExists.output === "") {
+        await runShellScript("curl -L https://foundry.paradigm.xyz | bash && export PATH=~/.foundry/bin:$PATH && foundryup");
+        spinner.succeed(chalk.green("foundry installed"));
+    }
+    else {
+        spinner.succeed(chalk.green("foundry is aleady installed"));
+    }
+}


### PR DESCRIPTION
Added a setup procedure before the CLI starts that installs jq and foundry, tools that are mandatory for running Ainte.

Both foundry and jq installations are cross-platform for both Unix and MacOS. 

Resolves #12 